### PR TITLE
condastat: add write_actual_condastat method

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -28,7 +28,7 @@ click==8.1.3
     #   pip-tools
 commonmark==0.9.1
     # via rich
-coverage==6.4.2
+coverage==6.4.3
     # via -r dev-requirements.in
 cryptography==37.0.4
     # via secretstorage
@@ -38,7 +38,7 @@ distlib==0.3.5
     # via virtualenv
 docutils==0.19
     # via readme-renderer
-filelock==3.7.1
+filelock==3.8.0
     # via virtualenv
 identify==2.5.3
     # via pre-commit
@@ -56,7 +56,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via pdoc
-keyring==23.7.0
+keyring==23.8.2
     # via twine
 lazy-object-proxy==1.7.1
     # via astroid
@@ -78,7 +78,7 @@ packaging==21.3
     # via build
 pathspec==0.9.0
     # via black
-pdoc==12.0.2
+pdoc==12.1.0
     # via -r dev-requirements.in
 pep517==0.13.0
     # via build
@@ -106,7 +106,7 @@ pyparsing==3.0.9
     # via packaging
 pyyaml==6.0
     # via pre-commit
-readme-renderer==35.0
+readme-renderer==36.0
     # via twine
 requests==2.28.1
     # via
@@ -133,7 +133,7 @@ tomli==2.0.1
     #   mypy
     #   pep517
     #   pylint
-tomlkit==0.11.1
+tomlkit==0.11.4
     # via pylint
 twine==4.0.1
     # via -r dev-requirements.in
@@ -148,7 +148,7 @@ urllib3==1.26.11
     # via
     #   requests
     #   twine
-virtualenv==20.16.2
+virtualenv==20.16.3
     # via pre-commit
 webencodings==0.5.1
     # via bleach

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 pandas
-dask
-pyarrow
-s3fs
+dask==2022.8.0
+pyarrow==9.0.0
+fsspec==2022.7.1
+aiohttp==3.8.1
+aiobotocore==2.3.4
+botocore==1.24.21
+s3fs==2022.7.1

--- a/tests/assets/tests_ref/nan_actual.csv
+++ b/tests/assets/tests_ref/nan_actual.csv
@@ -1,0 +1,2 @@
+date,data_source,pkg_version,downloads
+today,nan,nan,0

--- a/tests/assets/tests_ref/nan_with_packagename_actual.csv
+++ b/tests/assets/tests_ref/nan_with_packagename_actual.csv
@@ -1,0 +1,2 @@
+date,package,data_source,pkg_version,downloads
+today,not-available-package,nan,nan,0

--- a/tests/test_actual_condastat.py
+++ b/tests/test_actual_condastat.py
@@ -1,0 +1,155 @@
+"""A module for testing the writecondastat.condastat module."""
+
+import unittest
+import unittest.mock
+from pathlib import Path
+from datetime import datetime, date
+
+from writecondastat.statdate import StatPeriod
+from writecondastat.condastat import CondaStatDataSource, WriteCondaStat
+
+
+PATH = Path(__file__).parent
+
+
+class TestWriteActualCondaStat(unittest.TestCase):
+    """A class for testing WriteCondaStat.write_actual_condastat() method."""
+
+    def test_if_stats_are_not_available(self) -> None:
+        """
+        A method for testing WriteCondaStat.write_actual_condastat()
+        if stats are not available.
+        """
+
+        outdir = f"{PATH}/.unittest/test_condastat/test_stats_are_not_available_actual"
+        write_conda_stat = WriteCondaStat("not-available-package", outdir)
+        write_conda_stat.fill_no_data = False
+        write_conda_stat.merge_stored_data = False
+        write_conda_stat.write_actual_condastat(
+            CondaStatDataSource.CONDAFORGE,
+        )
+        csv = f"{outdir}/2022_condastat.csv"
+        self.assertEqual((csv, Path(csv).is_file()), (csv, False))
+
+    def test_stats_fill_no_data_and_write_package_name(self) -> None:
+        """
+        A method for testing WriteCondaStat.write_actual_condastat()
+        if fill no data and write package name.
+        """
+
+        outdir = f"{PATH}/.unittest/test_condastat/test_fill_no_data_and_write_package_name_actual"
+        write_conda_stat = WriteCondaStat("not-available-package", outdir)
+        write_conda_stat.write_package_name = True
+        write_conda_stat.fill_no_data = True
+        write_conda_stat.merge_stored_data = False
+        write_conda_stat.write_actual_condastat(
+            CondaStatDataSource.CONDAFORGE,
+        )
+        csv = f"{outdir}/2022_condastat_actual.csv"
+        with open(csv, "r", encoding="utf8") as out, open(
+            f"{PATH}/assets/tests_ref/nan_with_packagename_actual.csv",
+            "r",
+            encoding="utf8",
+        ) as ref:
+            self.assertTrue(
+                out.read(),
+                ref.read().replace("today", datetime.now().strftime("%Y-%m-%d")),
+            )
+
+    def test_stats_fill_no_data_and_not_write_package_name(self) -> None:
+        """
+        A method for testing WriteCondaStat.write_actual_condastat()
+        if fill no data and not write package name.
+        """
+
+        outdir = f"{PATH}/.unittest/test_condastat/test_fill_no_data_actual"
+        write_conda_stat = WriteCondaStat("not-available-package", outdir)
+        write_conda_stat.fill_no_data = True
+        write_conda_stat.merge_stored_data = False
+        write_conda_stat.write_actual_condastat(
+            CondaStatDataSource.CONDAFORGE,
+        )
+        csv = f"{outdir}/2022_condastat_actual.csv"
+        with open(csv, "r", encoding="utf8") as out, open(
+            f"{PATH}/assets/tests_ref/nan_actual.csv",
+            "r",
+            encoding="utf8",
+        ) as ref:
+            self.assertTrue(
+                out.read(),
+                ref.read().replace("today", datetime.now().strftime("%Y-%m-%d")),
+            )
+
+    def test_date_period_with_year(self) -> None:
+        """A method for testing WriteCondaStat.date_period with year."""
+
+        outdir = f"{PATH}/.unittest/test_condastat/test_date_period_year_actual"
+        write_conda_stat = WriteCondaStat("pandas", outdir)
+        write_conda_stat.fill_no_data = False
+        write_conda_stat.merge_stored_data = False
+        write_conda_stat.date_period = StatPeriod.YEAR
+        write_conda_stat.write_actual_condastat(
+            CondaStatDataSource.CONDAFORGE,
+        )
+        year = date.today().strftime("%Y")
+        csv = f"{outdir}/{year}_condastat_actual.csv"
+        self.assertEqual(
+            (csv, Path(csv).is_file()),
+            (csv, True),
+        )
+
+    def test_date_period_with_month(self) -> None:
+        """A method for testing WriteCondaStat.date_period with month."""
+
+        outdir = f"{PATH}/.unittest/test_condastat/test_date_period_month_actual"
+        write_conda_stat = WriteCondaStat("pandas", outdir)
+        write_conda_stat.fill_no_data = False
+        write_conda_stat.merge_stored_data = False
+        write_conda_stat.date_period = StatPeriod.MONTH
+        write_conda_stat.write_actual_condastat(
+            CondaStatDataSource.CONDAFORGE,
+        )
+        year = date.today().strftime("%Y")
+        month = date.today().strftime("%m")
+        csv = f"{outdir}/{year}-{month}_condastat_actual.csv"
+        self.assertEqual(
+            (csv, Path(csv).is_file()),
+            (csv, True),
+        )
+
+    def test_date_period_with_day(self) -> None:
+        """A method for testing WriteCondaStat.date_period with day."""
+
+        outdir = f"{PATH}/.unittest/test_condastat/test_date_period_day_actual"
+        write_conda_stat = WriteCondaStat("pandas", outdir)
+        write_conda_stat.fill_no_data = False
+        write_conda_stat.merge_stored_data = False
+        write_conda_stat.date_period = StatPeriod.DAY
+        write_conda_stat.write_actual_condastat(
+            CondaStatDataSource.CONDAFORGE,
+        )
+        year = date.today().strftime("%Y")
+        month = date.today().strftime("%m")
+        day = date.today().strftime("%d")
+        csv = f"{outdir}/{year}-{month}-{day}_condastat_actual.csv"
+        self.assertEqual(
+            (csv, Path(csv).is_file()),
+            (csv, True),
+        )
+
+    def test_date_period_with_none(self) -> None:
+        """A method for testing WriteCondaStat.date_period with none."""
+
+        outdir = f"{PATH}/.unittest/test_condastat/test_date_period_none_actual"
+        write_conda_stat = WriteCondaStat("pandas", outdir)
+        write_conda_stat.fill_no_data = False
+        write_conda_stat.merge_stored_data = False
+        write_conda_stat.date_period = StatPeriod.NONE
+        write_conda_stat.write_actual_condastat(
+            CondaStatDataSource.CONDAFORGE,
+        )
+        csv = f"{outdir}/condastat_actual.csv"
+        self.assertEqual(
+            (csv, Path(csv).is_file()),
+            (csv, True),
+        )


### PR DESCRIPTION
## Issue ticket link
resolve #3 

## Describe your changes
add write_actual_condastat method, with this, it is possible to download the actual sum of downloads

## Type of change (Please delete options that are not relevant)

- [x] New feature (non-breaking change which adds functionality)
